### PR TITLE
fixes #5 uses write instead of append flag

### DIFF
--- a/lib/wget.js
+++ b/lib/wget.js
@@ -33,7 +33,7 @@ function download(src, output, options) {
             downloadedSize = 0;
             fileSize = res.headers['content-length'];
             writeStream = fs.createWriteStream(output, {
-                flags: 'a',
+                flags: 'w',
                 encoding: 'binary'
             });
 


### PR DESCRIPTION
the module currently appends the downloaded content if a file with the same path already exists. This is usually not what you want. So I've changed the flag for the writeStream to `w`.
