### PR TITLE
Let the get parameters in the path

### DIFF
--- a/lib/wget.js
+++ b/lib/wget.js
@@ -24,7 +24,7 @@ function download(src, output, options) {
         protocol: srcUrl.protocol,
         host: srcUrl.hostname,
         port: srcUrl.port,
-        path: srcUrl.pathname + srcUrl.search,
+        path: srcUrl.pathname + (srcUrl.search || ""),
         proxy: options?options.proxy:undefined,
         method: 'GET'
     }, function(res) {

--- a/lib/wget.js
+++ b/lib/wget.js
@@ -24,7 +24,7 @@ function download(src, output, options) {
         protocol: srcUrl.protocol,
         host: srcUrl.hostname,
         port: srcUrl.port,
-        path: srcUrl.pathname,
+        path: srcUrl.pathname + srcUrl.search,
         proxy: options?options.proxy:undefined,
         method: 'GET'
     }, function(res) {


### PR DESCRIPTION
If the path contains some GET-parameters, your library just truncates them. Here is the fix.
